### PR TITLE
feat: Initialize packet capture with gopacket

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/tu-usuario/go-sniffer
+
+go 1.24.3
+
+require github.com/google/gopacket v1.1.19 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,14 @@
+github.com/google/gopacket v1.1.19 h1:ves8RnFZPGiFnTS0uPQStjwru6uO6h+nlr9j6fL7kF8=
+github.com/google/gopacket v1.1.19/go.mod h1:iJ8V8n6KS+z2U1A8pUwu8bW5SyEMkXJB8Yo/Vo+TKTo=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/lint v0.0.0-20200302205851-738671d3881b/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
+golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
+golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/tools v0.0.0-20200130002326-2f3ba24bd6e7/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
+golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/main.go
+++ b/main.go
@@ -1,0 +1,57 @@
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	"github.com/google/gopacket"
+	"github.com/google/gopacket/pcap"
+)
+
+func main() {
+	// List network interfaces
+	devices, err := pcap.FindAllDevs()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Flag for selecting the interface
+	list := flag.Bool("list", false, "List all available network interfaces")
+	device := flag.String("device", "", "Network interface to capture packets from")
+	flag.Parse()
+
+	if *list || (*device == "" && len(os.Args) == 1) {
+		fmt.Println("Available network interfaces:")
+		for _, d := range devices {
+			fmt.Printf("Name: %s\n", d.Name)
+			fmt.Printf("Description: %s\n", d.Description)
+			fmt.Println("-----------")
+		}
+		if *device == "" {
+			return
+		}
+	}
+
+	if *device == "" {
+		log.Fatal("Please specify the network interface to capture packets from with the -device flag")
+	}
+
+	// Open device
+	handle, err := pcap.OpenLive(*device, 1024, true, pcap.BlockForever)
+	if err != nil {
+		log.Fatalf("Error opening device %s: %v. Try running with sudo.", *device, err)
+	}
+	defer handle.Close()
+
+	// Use a PacketSource to process packets
+	packetSource := gopacket.NewPacketSource(handle, handle.LinkType())
+	fmt.Printf("Capturing packets on device %s...\n", *device)
+	for packet := range packetSource.Packets() {
+		// Process packets here
+		fmt.Printf("Paquete capturado: [%s] Longitud: [%d] bytes\n", packet.Metadata().Timestamp.Format(time.RFC3339Nano), len(packet.Data()))
+	}
+}


### PR DESCRIPTION
This PR introduces the initial version of the go-sniffer tool. It can list network interfaces and capture packets from a selected interface, printing a summary for each packet.

Fixes #1

---
*PR created automatically by Jules for task [13785633035878554269](https://jules.google.com/task/13785633035878554269) started by @Villata-dev*