### PR TITLE
Add -output flag to export captures to .pcap format

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ Para iniciar la captura en una interfaz específica (ej: `eth0`) con un filtro B
 sudo ./go-sniffer -device eth0 -filter "tcp port 80"
 ```
 
+Para guardar los paquetes capturados en un archivo .pcap compatible con Wireshark:
+
+```bash
+sudo ./go-sniffer -device eth0 -output captura.pcap
+```
+
 Si deseas capturar todo el tráfico IPv4 en `eth0`:
 
 ```bash


### PR DESCRIPTION
This PR adds the ability to save captured network packets into a standard .pcap file, compatible with analysis tools like Wireshark. It introduces a new `-output` flag, handles file creation and header writing using `gopacket/pcapgo`, and ensures that packets are recorded during the capture session without interfering with the real-time console display. Documentation in README.md has been updated to include this new feature.

Fixes #13

---
*PR created automatically by Jules for task [11799427422324855601](https://jules.google.com/task/11799427422324855601) started by @Villata-dev*